### PR TITLE
Add composer autoload in quickstart.php

### DIFF
--- a/drive/quickstart/quickstart.php
+++ b/drive/quickstart/quickstart.php
@@ -15,6 +15,9 @@
  * limitations under the License.
  */
 // [START drive_quickstart]
+
+require __DIR__ . '/vendor/autoload.php';
+
 /**
  * Returns an authorized API client.
  * @return Google_Client the authorized client object


### PR DESCRIPTION
https://getcomposer.org/doc/01-basic-usage.md#autoloading

Otherwise, following error was throw:

```shell
PHP Fatal error:  Uncaught Error: Class 'Google_Client' not found in /folder/google-drive-api/quickstart.php:8
Stack trace:
#0 /folder/google-drive-api/quickstart.php(60): getClient()
#1 {main}
  thrown in /folder/google-drive-api/quickstart.php on line 8

Fatal error: Uncaught Error: Class 'Google_Client' not found in /folder/google-drive-api/quickstart.php on line 8

Error: Class 'Google_Client' not found in /folder/google-drive-api/quickstart.php on line 8

Call Stack:
    0.0010     411688   1. {main}() /folder/google-drive-api/quickstart.php:0
    0.0011     411688   2. getClient() /folder/google-drive-api/quickstart.php:60
```