### PR TITLE
Handle missing refresh tokens in the quickstarts

### DIFF
--- a/admin-sdk/directory/quickstart.php
+++ b/admin-sdk/directory/quickstart.php
@@ -32,39 +32,41 @@ function getClient()
     $client->setScopes(Google_Service_Directory::ADMIN_DIRECTORY_USER_READONLY);
     $client->setAuthConfig('credentials.json');
     $client->setAccessType('offline');
+    $client->setPrompt('select_account consent');
 
-    // Load previously authorized credentials from a file.
-    $credentialsPath = 'token.json';
-    if (file_exists($credentialsPath)) {
-        $accessToken = json_decode(file_get_contents($credentialsPath), true);
-    } else {
-        // Request authorization from the user.
-        $authUrl = $client->createAuthUrl();
-        printf("Open the following link in your browser:\n%s\n", $authUrl);
-        print 'Enter verification code: ';
-        $authCode = trim(fgets(STDIN));
-
-        // Exchange authorization code for an access token.
-        $accessToken = $client->fetchAccessTokenWithAuthCode($authCode);
-
-        // Check to see if there was an error.
-        if (array_key_exists('error', $accessToken)) {
-            throw new Exception(join(', ', $accessToken));
-        }
-
-        // Store the credentials to disk.
-        if (!file_exists(dirname($credentialsPath))) {
-            mkdir(dirname($credentialsPath), 0700, true);
-        }
-        file_put_contents($credentialsPath, json_encode($accessToken));
-        printf("Credentials saved to %s\n", $credentialsPath);
+    // Load previously authorized token from a file, if it exists.
+    $tokenPath = 'token.json';
+    if (file_exists($tokenPath)) {
+        $accessToken = json_decode(file_get_contents($tokenPath), true);
+        $client->setAccessToken($accessToken);
     }
-    $client->setAccessToken($accessToken);
 
-    // Refresh the token if it's expired.
+    // If there is no previous token or it's expired.
     if ($client->isAccessTokenExpired()) {
-        $client->fetchAccessTokenWithRefreshToken($client->getRefreshToken());
-        file_put_contents($credentialsPath, json_encode($client->getAccessToken()));
+        // Refresh the token if possible, else fetch a new one.
+        if($client->getRefreshToken()) {
+            $client->fetchAccessTokenWithRefreshToken($client->getRefreshToken());
+        } else {
+            // Request authorization from the user.
+            $authUrl = $client->createAuthUrl();
+            printf("Open the following link in your browser:\n%s\n", $authUrl);
+            print 'Enter verification code: ';
+            $authCode = trim(fgets(STDIN));
+
+            // Exchange authorization code for an access token.
+            $accessToken = $client->fetchAccessTokenWithAuthCode($authCode);
+            $client->setAccessToken($accessToken);
+
+            // Check to see if there was an error.
+            if (array_key_exists('error', $accessToken)) {
+                throw new Exception(join(', ', $accessToken));
+            }
+        }
+        // Save the token to a file.
+        if (!file_exists(dirname($tokenPath))) {
+            mkdir(dirname($tokenPath), 0700, true);
+        }
+        file_put_contents($tokenPath, json_encode($client->getAccessToken()));
     }
     return $client;
 }

--- a/admin-sdk/directory/quickstart.php
+++ b/admin-sdk/directory/quickstart.php
@@ -44,7 +44,7 @@ function getClient()
     // If there is no previous token or it's expired.
     if ($client->isAccessTokenExpired()) {
         // Refresh the token if possible, else fetch a new one.
-        if($client->getRefreshToken()) {
+        if ($client->getRefreshToken()) {
             $client->fetchAccessTokenWithRefreshToken($client->getRefreshToken());
         } else {
             // Request authorization from the user.

--- a/admin-sdk/reports/quickstart.php
+++ b/admin-sdk/reports/quickstart.php
@@ -32,39 +32,41 @@ function getClient()
     $client->setScopes(Google_Service_Reports::ADMIN_REPORTS_AUDIT_READONLY);
     $client->setAuthConfig('credentials.json');
     $client->setAccessType('offline');
+    $client->setPrompt('select_account consent');
 
-    // Load previously authorized credentials from a file.
-    $credentialsPath = 'token.json';
-    if (file_exists($credentialsPath)) {
-        $accessToken = json_decode(file_get_contents($credentialsPath), true);
-    } else {
-        // Request authorization from the user.
-        $authUrl = $client->createAuthUrl();
-        printf("Open the following link in your browser:\n%s\n", $authUrl);
-        print 'Enter verification code: ';
-        $authCode = trim(fgets(STDIN));
-
-        // Exchange authorization code for an access token.
-        $accessToken = $client->fetchAccessTokenWithAuthCode($authCode);
-
-        // Check to see if there was an error.
-        if (array_key_exists('error', $accessToken)) {
-            throw new Exception(join(', ', $accessToken));
-        }
-
-        // Store the credentials to disk.
-        if (!file_exists(dirname($credentialsPath))) {
-            mkdir(dirname($credentialsPath), 0700, true);
-        }
-        file_put_contents($credentialsPath, json_encode($accessToken));
-        printf("Credentials saved to %s\n", $credentialsPath);
+    // Load previously authorized token from a file, if it exists.
+    $tokenPath = 'token.json';
+    if (file_exists($tokenPath)) {
+        $accessToken = json_decode(file_get_contents($tokenPath), true);
+        $client->setAccessToken($accessToken);
     }
-    $client->setAccessToken($accessToken);
 
-    // Refresh the token if it's expired.
+    // If there is no previous token or it's expired.
     if ($client->isAccessTokenExpired()) {
-        $client->fetchAccessTokenWithRefreshToken($client->getRefreshToken());
-        file_put_contents($credentialsPath, json_encode($client->getAccessToken()));
+        // Refresh the token if possible, else fetch a new one.
+        if($client->getRefreshToken()) {
+            $client->fetchAccessTokenWithRefreshToken($client->getRefreshToken());
+        } else {
+            // Request authorization from the user.
+            $authUrl = $client->createAuthUrl();
+            printf("Open the following link in your browser:\n%s\n", $authUrl);
+            print 'Enter verification code: ';
+            $authCode = trim(fgets(STDIN));
+
+            // Exchange authorization code for an access token.
+            $accessToken = $client->fetchAccessTokenWithAuthCode($authCode);
+            $client->setAccessToken($accessToken);
+
+            // Check to see if there was an error.
+            if (array_key_exists('error', $accessToken)) {
+                throw new Exception(join(', ', $accessToken));
+            }
+        }
+        // Save the token to a file.
+        if (!file_exists(dirname($tokenPath))) {
+            mkdir(dirname($tokenPath), 0700, true);
+        }
+        file_put_contents($tokenPath, json_encode($client->getAccessToken()));
     }
     return $client;
 }

--- a/admin-sdk/reports/quickstart.php
+++ b/admin-sdk/reports/quickstart.php
@@ -44,7 +44,7 @@ function getClient()
     // If there is no previous token or it's expired.
     if ($client->isAccessTokenExpired()) {
         // Refresh the token if possible, else fetch a new one.
-        if($client->getRefreshToken()) {
+        if ($client->getRefreshToken()) {
             $client->fetchAccessTokenWithRefreshToken($client->getRefreshToken());
         } else {
             // Request authorization from the user.

--- a/admin-sdk/reseller/quickstart.php
+++ b/admin-sdk/reseller/quickstart.php
@@ -32,56 +32,45 @@ function getClient()
     $client->setScopes(Google_Service_Reseller::APPS_ORDER);
     $client->setAuthConfig('credentials.json');
     $client->setAccessType('offline');
+    $client->setPrompt('select_account consent');
 
-    // Load previously authorized credentials from a file.
-    $credentialsPath = 'token.json';
-    if (file_exists($credentialsPath)) {
-        $accessToken = json_decode(file_get_contents($credentialsPath), true);
-    } else {
-        // Request authorization from the user.
-        $authUrl = $client->createAuthUrl();
-        printf("Open the following link in your browser:\n%s\n", $authUrl);
-        print 'Enter verification code: ';
-        $authCode = trim(fgets(STDIN));
-
-        // Exchange authorization code for an access token.
-        $accessToken = $client->fetchAccessTokenWithAuthCode($authCode);
-
-        // Check to see if there was an error.
-        if (array_key_exists('error', $accessToken)) {
-            throw new Exception(join(', ', $accessToken));
-        }
-
-        // Store the credentials to disk.
-        if (!file_exists(dirname($credentialsPath))) {
-            mkdir(dirname($credentialsPath), 0700, true);
-        }
-        file_put_contents($credentialsPath, json_encode($accessToken));
-        printf("Credentials saved to %s\n", $credentialsPath);
+    // Load previously authorized token from a file, if it exists.
+    $tokenPath = 'token.json';
+    if (file_exists($tokenPath)) {
+        $accessToken = json_decode(file_get_contents($tokenPath), true);
+        $client->setAccessToken($accessToken);
     }
-    $client->setAccessToken($accessToken);
 
-    // Refresh the token if it's expired.
+    // If there is no previous token or it's expired.
     if ($client->isAccessTokenExpired()) {
-        $client->fetchAccessTokenWithRefreshToken($client->getRefreshToken());
-        file_put_contents($credentialsPath, json_encode($client->getAccessToken()));
+        // Refresh the token if possible, else fetch a new one.
+        if($client->getRefreshToken()) {
+            $client->fetchAccessTokenWithRefreshToken($client->getRefreshToken());
+        } else {
+            // Request authorization from the user.
+            $authUrl = $client->createAuthUrl();
+            printf("Open the following link in your browser:\n%s\n", $authUrl);
+            print 'Enter verification code: ';
+            $authCode = trim(fgets(STDIN));
+
+            // Exchange authorization code for an access token.
+            $accessToken = $client->fetchAccessTokenWithAuthCode($authCode);
+            $client->setAccessToken($accessToken);
+
+            // Check to see if there was an error.
+            if (array_key_exists('error', $accessToken)) {
+                throw new Exception(join(', ', $accessToken));
+            }
+        }
+        // Save the token to a file.
+        if (!file_exists(dirname($tokenPath))) {
+            mkdir(dirname($tokenPath), 0700, true);
+        }
+        file_put_contents($tokenPath, json_encode($client->getAccessToken()));
     }
     return $client;
 }
 
-/**
- * Expands the home directory alias '~' to the full path.
- * @param string $path the path to expand.
- * @return string the expanded path.
- */
-function expandHomeDirectory($path)
-{
-    $homeDirectory = getenv('HOME');
-    if (empty($homeDirectory)) {
-        $homeDirectory = getenv('HOMEDRIVE') . getenv('HOMEPATH');
-    }
-    return str_replace('~', realpath($homeDirectory), $path);
-}
 
 // Get the API client and construct the service object.
 $client = getClient();

--- a/admin-sdk/reseller/quickstart.php
+++ b/admin-sdk/reseller/quickstart.php
@@ -44,7 +44,7 @@ function getClient()
     // If there is no previous token or it's expired.
     if ($client->isAccessTokenExpired()) {
         // Refresh the token if possible, else fetch a new one.
-        if($client->getRefreshToken()) {
+        if ($client->getRefreshToken()) {
             $client->fetchAccessTokenWithRefreshToken($client->getRefreshToken());
         } else {
             // Request authorization from the user.

--- a/apps-script/quickstart/quickstart.php
+++ b/apps-script/quickstart/quickstart.php
@@ -44,7 +44,7 @@ function getClient()
     // If there is no previous token or it's expired.
     if ($client->isAccessTokenExpired()) {
         // Refresh the token if possible, else fetch a new one.
-        if($client->getRefreshToken()) {
+        if ($client->getRefreshToken()) {
             $client->fetchAccessTokenWithRefreshToken($client->getRefreshToken());
         } else {
             // Request authorization from the user.

--- a/apps-script/quickstart/quickstart.php
+++ b/apps-script/quickstart/quickstart.php
@@ -32,39 +32,41 @@ function getClient()
     $client->setScopes("https://www.googleapis.com/auth/script.projects");
     $client->setAuthConfig('credentials.json');
     $client->setAccessType('offline');
+    $client->setPrompt('select_account consent');
 
-    // Load previously authorized credentials from a file.
-    $credentialsPath = 'token.json';
-    if (file_exists($credentialsPath)) {
-        $accessToken = json_decode(file_get_contents($credentialsPath), true);
-    } else {
-        // Request authorization from the user.
-        $authUrl = $client->createAuthUrl();
-        printf("Open the following link in your browser:\n%s\n", $authUrl);
-        print 'Enter verification code: ';
-        $authCode = trim(fgets(STDIN));
-
-        // Exchange authorization code for an access token.
-        $accessToken = $client->fetchAccessTokenWithAuthCode($authCode);
-
-        // Check to see if there was an error.
-        if (array_key_exists('error', $accessToken)) {
-            throw new Exception(join(', ', $accessToken));
-        }
-
-        // Store the credentials to disk.
-        if (!file_exists(dirname($credentialsPath))) {
-            mkdir(dirname($credentialsPath), 0700, true);
-        }
-        file_put_contents($credentialsPath, json_encode($accessToken));
-        printf("Credentials saved to %s\n", $credentialsPath);
+    // Load previously authorized token from a file, if it exists.
+    $tokenPath = 'token.json';
+    if (file_exists($tokenPath)) {
+        $accessToken = json_decode(file_get_contents($tokenPath), true);
+        $client->setAccessToken($accessToken);
     }
-    $client->setAccessToken($accessToken);
 
-    // Refresh the token if it's expired.
+    // If there is no previous token or it's expired.
     if ($client->isAccessTokenExpired()) {
-        $client->fetchAccessTokenWithRefreshToken($client->getRefreshToken());
-        file_put_contents($credentialsPath, json_encode($client->getAccessToken()));
+        // Refresh the token if possible, else fetch a new one.
+        if($client->getRefreshToken()) {
+            $client->fetchAccessTokenWithRefreshToken($client->getRefreshToken());
+        } else {
+            // Request authorization from the user.
+            $authUrl = $client->createAuthUrl();
+            printf("Open the following link in your browser:\n%s\n", $authUrl);
+            print 'Enter verification code: ';
+            $authCode = trim(fgets(STDIN));
+
+            // Exchange authorization code for an access token.
+            $accessToken = $client->fetchAccessTokenWithAuthCode($authCode);
+            $client->setAccessToken($accessToken);
+
+            // Check to see if there was an error.
+            if (array_key_exists('error', $accessToken)) {
+                throw new Exception(join(', ', $accessToken));
+            }
+        }
+        // Save the token to a file.
+        if (!file_exists(dirname($tokenPath))) {
+            mkdir(dirname($tokenPath), 0700, true);
+        }
+        file_put_contents($tokenPath, json_encode($client->getAccessToken()));
     }
     return $client;
 }
@@ -86,22 +88,31 @@ $response = $service->projects->create($request);
 
 $scriptId = $response->getScriptId();
 
+$code = <<<EOT
+function helloWorld() {
+  console.log('Hello, world!');
+}
+EOT;
 $file1 = new Google_Service_Script_ScriptFile();
 $file1->setName('hello');
 $file1->setType('SERVER_JS');
-$file1->setSource("function helloWorld() {\n  console.log(\"Hello, world!\"" +
-                  ");\n}");
+$file1->setSource($code);
 
+$manifest = <<<EOT
+{
+  "timeZone": "America/New_York",
+  "exceptionLogging": "CLOUD"
+}
+EOT;
 $file2 = new Google_Service_Script_ScriptFile();
 $file2->setName('appsscript');
 $file2->setType('JSON');
-$file2->setSource("{\"timeZone\":\"America/New_York\",\"exceptionLogging\"" +
-                  ":\"CLOUD\"}");
+$file2->setSource($manifest);
 
 $request = new Google_Service_Script_Content();
 $request->setScriptId($scriptId);
 $request->setFiles([$file1, $file2]);
 
 $response = $service->projects->updateContent($scriptId, $request);
-echo 'https://script.google.com/d/' . $response->getScriptId() . '/edit';
+echo "https://script.google.com/d/" . $response->getScriptId() . "/edit\n";
 // [END apps_script_api_quickstart]

--- a/calendar/quickstart/quickstart.php
+++ b/calendar/quickstart/quickstart.php
@@ -32,39 +32,41 @@ function getClient()
     $client->setScopes(Google_Service_Calendar::CALENDAR_READONLY);
     $client->setAuthConfig('credentials.json');
     $client->setAccessType('offline');
+    $client->setPrompt('select_account consent');
 
-    // Load previously authorized credentials from a file.
-    $credentialsPath = 'token.json';
-    if (file_exists($credentialsPath)) {
-        $accessToken = json_decode(file_get_contents($credentialsPath), true);
-    } else {
-        // Request authorization from the user.
-        $authUrl = $client->createAuthUrl();
-        printf("Open the following link in your browser:\n%s\n", $authUrl);
-        print 'Enter verification code: ';
-        $authCode = trim(fgets(STDIN));
-
-        // Exchange authorization code for an access token.
-        $accessToken = $client->fetchAccessTokenWithAuthCode($authCode);
-
-        // Check to see if there was an error.
-        if (array_key_exists('error', $accessToken)) {
-            throw new Exception(join(', ', $accessToken));
-        }
-
-        // Store the credentials to disk.
-        if (!file_exists(dirname($credentialsPath))) {
-            mkdir(dirname($credentialsPath), 0700, true);
-        }
-        file_put_contents($credentialsPath, json_encode($accessToken));
-        printf("Credentials saved to %s\n", $credentialsPath);
+    // Load previously authorized token from a file, if it exists.
+    $tokenPath = 'token.json';
+    if (file_exists($tokenPath)) {
+        $accessToken = json_decode(file_get_contents($tokenPath), true);
+        $client->setAccessToken($accessToken);
     }
-    $client->setAccessToken($accessToken);
 
-    // Refresh the token if it's expired.
+    // If there is no previous token or it's expired.
     if ($client->isAccessTokenExpired()) {
-        $client->fetchAccessTokenWithRefreshToken($client->getRefreshToken());
-        file_put_contents($credentialsPath, json_encode($client->getAccessToken()));
+        // Refresh the token if possible, else fetch a new one.
+        if($client->getRefreshToken()) {
+            $client->fetchAccessTokenWithRefreshToken($client->getRefreshToken());
+        } else {
+            // Request authorization from the user.
+            $authUrl = $client->createAuthUrl();
+            printf("Open the following link in your browser:\n%s\n", $authUrl);
+            print 'Enter verification code: ';
+            $authCode = trim(fgets(STDIN));
+
+            // Exchange authorization code for an access token.
+            $accessToken = $client->fetchAccessTokenWithAuthCode($authCode);
+            $client->setAccessToken($accessToken);
+
+            // Check to see if there was an error.
+            if (array_key_exists('error', $accessToken)) {
+                throw new Exception(join(', ', $accessToken));
+            }
+        }
+        // Save the token to a file.
+        if (!file_exists(dirname($tokenPath))) {
+            mkdir(dirname($tokenPath), 0700, true);
+        }
+        file_put_contents($tokenPath, json_encode($client->getAccessToken()));
     }
     return $client;
 }

--- a/calendar/quickstart/quickstart.php
+++ b/calendar/quickstart/quickstart.php
@@ -44,7 +44,7 @@ function getClient()
     // If there is no previous token or it's expired.
     if ($client->isAccessTokenExpired()) {
         // Refresh the token if possible, else fetch a new one.
-        if($client->getRefreshToken()) {
+        if ($client->getRefreshToken()) {
             $client->fetchAccessTokenWithRefreshToken($client->getRefreshToken());
         } else {
             // Request authorization from the user.

--- a/classroom/quickstart/quickstart.php
+++ b/classroom/quickstart/quickstart.php
@@ -32,39 +32,41 @@ function getClient()
     $client->setScopes(Google_Service_Classroom::CLASSROOM_COURSES_READONLY);
     $client->setAuthConfig('credentials.json');
     $client->setAccessType('offline');
+    $client->setPrompt('select_account consent');
 
-    // Load previously authorized credentials from a file.
-    $credentialsPath = 'token.json';
-    if (file_exists($credentialsPath)) {
-        $accessToken = json_decode(file_get_contents($credentialsPath), true);
-    } else {
-        // Request authorization from the user.
-        $authUrl = $client->createAuthUrl();
-        printf("Open the following link in your browser:\n%s\n", $authUrl);
-        print 'Enter verification code: ';
-        $authCode = trim(fgets(STDIN));
-
-        // Exchange authorization code for an access token.
-        $accessToken = $client->fetchAccessTokenWithAuthCode($authCode);
-
-        // Check to see if there was an error.
-        if (array_key_exists('error', $accessToken)) {
-            throw new Exception(join(', ', $accessToken));
-        }
-
-        // Store the credentials to disk.
-        if (!file_exists(dirname($credentialsPath))) {
-            mkdir(dirname($credentialsPath), 0700, true);
-        }
-        file_put_contents($credentialsPath, json_encode($accessToken));
-        printf("Credentials saved to %s\n", $credentialsPath);
+    // Load previously authorized token from a file, if it exists.
+    $tokenPath = 'token.json';
+    if (file_exists($tokenPath)) {
+        $accessToken = json_decode(file_get_contents($tokenPath), true);
+        $client->setAccessToken($accessToken);
     }
-    $client->setAccessToken($accessToken);
 
-    // Refresh the token if it's expired.
+    // If there is no previous token or it's expired.
     if ($client->isAccessTokenExpired()) {
-        $client->fetchAccessTokenWithRefreshToken($client->getRefreshToken());
-        file_put_contents($credentialsPath, json_encode($client->getAccessToken()));
+        // Refresh the token if possible, else fetch a new one.
+        if($client->getRefreshToken()) {
+            $client->fetchAccessTokenWithRefreshToken($client->getRefreshToken());
+        } else {
+            // Request authorization from the user.
+            $authUrl = $client->createAuthUrl();
+            printf("Open the following link in your browser:\n%s\n", $authUrl);
+            print 'Enter verification code: ';
+            $authCode = trim(fgets(STDIN));
+
+            // Exchange authorization code for an access token.
+            $accessToken = $client->fetchAccessTokenWithAuthCode($authCode);
+            $client->setAccessToken($accessToken);
+
+            // Check to see if there was an error.
+            if (array_key_exists('error', $accessToken)) {
+                throw new Exception(join(', ', $accessToken));
+            }
+        }
+        // Save the token to a file.
+        if (!file_exists(dirname($tokenPath))) {
+            mkdir(dirname($tokenPath), 0700, true);
+        }
+        file_put_contents($tokenPath, json_encode($client->getAccessToken()));
     }
     return $client;
 }

--- a/classroom/quickstart/quickstart.php
+++ b/classroom/quickstart/quickstart.php
@@ -44,7 +44,7 @@ function getClient()
     // If there is no previous token or it's expired.
     if ($client->isAccessTokenExpired()) {
         // Refresh the token if possible, else fetch a new one.
-        if($client->getRefreshToken()) {
+        if ($client->getRefreshToken()) {
             $client->fetchAccessTokenWithRefreshToken($client->getRefreshToken());
         } else {
             // Request authorization from the user.

--- a/drive/activity/quickstart.php
+++ b/drive/activity/quickstart.php
@@ -29,45 +29,44 @@ function getClient()
 {
     $client = new Google_Client();
     $client->setApplicationName('Google Drive Activity API Quickstart');
-    $client->setScopes(implode(' ', array(
-      Google_Service_Appsactivity::ACTIVITY,
-      Google_Service_Drive::DRIVE_METADATA_READONLY)
-    ));
+    $client->setScopes(Google_Service_Appsactivity::ACTIVITY);
     $client->setAuthConfig('credentials.json');
     $client->setAccessType('offline');
+    $client->setPrompt('select_account consent');
 
-    // Load previously authorized credentials from a file.
-    $credentialsPath = 'token.json';
-    if (file_exists($credentialsPath)) {
-        $accessToken = json_decode(file_get_contents($credentialsPath), true);
-    } else {
-        // Request authorization from the user.
-        $authUrl = $client->createAuthUrl();
-        printf("Open the following link in your browser:\n%s\n", $authUrl);
-        print 'Enter verification code: ';
-        $authCode = trim(fgets(STDIN));
-
-        // Exchange authorization code for an access token.
-        $accessToken = $client->fetchAccessTokenWithAuthCode($authCode);
-
-        // Check to see if there was an error.
-        if (array_key_exists('error', $accessToken)) {
-            throw new Exception(join(', ', $accessToken));
-        }
-
-        // Store the credentials to disk.
-        if (!file_exists(dirname($credentialsPath))) {
-            mkdir(dirname($credentialsPath), 0700, true);
-        }
-        file_put_contents($credentialsPath, json_encode($accessToken));
-        printf("Credentials saved to %s\n", $credentialsPath);
+    // Load previously authorized token from a file, if it exists.
+    $tokenPath = 'token.json';
+    if (file_exists($tokenPath)) {
+        $accessToken = json_decode(file_get_contents($tokenPath), true);
+        $client->setAccessToken($accessToken);
     }
-    $client->setAccessToken($accessToken);
 
-    // Refresh the token if it's expired.
+    // If there is no previous token or it's expired.
     if ($client->isAccessTokenExpired()) {
-        $client->fetchAccessTokenWithRefreshToken($client->getRefreshToken());
-        file_put_contents($credentialsPath, json_encode($client->getAccessToken()));
+        // Refresh the token if possible, else fetch a new one.
+        if($client->getRefreshToken()) {
+            $client->fetchAccessTokenWithRefreshToken($client->getRefreshToken());
+        } else {
+            // Request authorization from the user.
+            $authUrl = $client->createAuthUrl();
+            printf("Open the following link in your browser:\n%s\n", $authUrl);
+            print 'Enter verification code: ';
+            $authCode = trim(fgets(STDIN));
+
+            // Exchange authorization code for an access token.
+            $accessToken = $client->fetchAccessTokenWithAuthCode($authCode);
+            $client->setAccessToken($accessToken);
+
+            // Check to see if there was an error.
+            if (array_key_exists('error', $accessToken)) {
+                throw new Exception(join(', ', $accessToken));
+            }
+        }
+        // Save the token to a file.
+        if (!file_exists(dirname($tokenPath))) {
+            mkdir(dirname($tokenPath), 0700, true);
+        }
+        file_put_contents($tokenPath, json_encode($client->getAccessToken()));
     }
     return $client;
 }

--- a/drive/activity/quickstart.php
+++ b/drive/activity/quickstart.php
@@ -44,7 +44,7 @@ function getClient()
     // If there is no previous token or it's expired.
     if ($client->isAccessTokenExpired()) {
         // Refresh the token if possible, else fetch a new one.
-        if($client->getRefreshToken()) {
+        if ($client->getRefreshToken()) {
             $client->fetchAccessTokenWithRefreshToken($client->getRefreshToken());
         } else {
             // Request authorization from the user.

--- a/drive/quickstart/quickstart.php
+++ b/drive/quickstart/quickstart.php
@@ -32,39 +32,41 @@ function getClient()
     $client->setScopes(Google_Service_Drive::DRIVE_METADATA_READONLY);
     $client->setAuthConfig('credentials.json');
     $client->setAccessType('offline');
+    $client->setPrompt('select_account consent');
 
-    // Load previously authorized credentials from a file.
-    $credentialsPath = 'token.json';
-    if (file_exists($credentialsPath)) {
-        $accessToken = json_decode(file_get_contents($credentialsPath), true);
-    } else {
-        // Request authorization from the user.
-        $authUrl = $client->createAuthUrl();
-        printf("Open the following link in your browser:\n%s\n", $authUrl);
-        print 'Enter verification code: ';
-        $authCode = trim(fgets(STDIN));
-
-        // Exchange authorization code for an access token.
-        $accessToken = $client->fetchAccessTokenWithAuthCode($authCode);
-
-        // Check to see if there was an error.
-        if (array_key_exists('error', $accessToken)) {
-            throw new Exception(join(', ', $accessToken));
-        }
-
-        // Store the credentials to disk.
-        if (!file_exists(dirname($credentialsPath))) {
-            mkdir(dirname($credentialsPath), 0700, true);
-        }
-        file_put_contents($credentialsPath, json_encode($accessToken));
-        printf("Credentials saved to %s\n", $credentialsPath);
+    // Load previously authorized token from a file, if it exists.
+    $tokenPath = 'token.json';
+    if (file_exists($tokenPath)) {
+        $accessToken = json_decode(file_get_contents($tokenPath), true);
+        $client->setAccessToken($accessToken);
     }
-    $client->setAccessToken($accessToken);
 
-    // Refresh the token if it's expired.
+    // If there is no previous token or it's expired.
     if ($client->isAccessTokenExpired()) {
-        $client->fetchAccessTokenWithRefreshToken($client->getRefreshToken());
-        file_put_contents($credentialsPath, json_encode($client->getAccessToken()));
+        // Refresh the token if possible, else fetch a new one.
+        if($client->getRefreshToken()) {
+            $client->fetchAccessTokenWithRefreshToken($client->getRefreshToken());
+        } else {
+            // Request authorization from the user.
+            $authUrl = $client->createAuthUrl();
+            printf("Open the following link in your browser:\n%s\n", $authUrl);
+            print 'Enter verification code: ';
+            $authCode = trim(fgets(STDIN));
+
+            // Exchange authorization code for an access token.
+            $accessToken = $client->fetchAccessTokenWithAuthCode($authCode);
+            $client->setAccessToken($accessToken);
+
+            // Check to see if there was an error.
+            if (array_key_exists('error', $accessToken)) {
+                throw new Exception(join(', ', $accessToken));
+            }
+        }
+        // Save the token to a file.
+        if (!file_exists(dirname($tokenPath))) {
+            mkdir(dirname($tokenPath), 0700, true);
+        }
+        file_put_contents($tokenPath, json_encode($client->getAccessToken()));
     }
     return $client;
 }

--- a/drive/quickstart/quickstart.php
+++ b/drive/quickstart/quickstart.php
@@ -44,7 +44,7 @@ function getClient()
     // If there is no previous token or it's expired.
     if ($client->isAccessTokenExpired()) {
         // Refresh the token if possible, else fetch a new one.
-        if($client->getRefreshToken()) {
+        if ($client->getRefreshToken()) {
             $client->fetchAccessTokenWithRefreshToken($client->getRefreshToken());
         } else {
             // Request authorization from the user.

--- a/gmail/quickstart/quickstart.php
+++ b/gmail/quickstart/quickstart.php
@@ -32,39 +32,41 @@ function getClient()
     $client->setScopes(Google_Service_Gmail::GMAIL_READONLY);
     $client->setAuthConfig('credentials.json');
     $client->setAccessType('offline');
+    $client->setPrompt('select_account consent');
 
-    // Load previously authorized credentials from a file.
-    $credentialsPath = 'token.json';
-    if (file_exists($credentialsPath)) {
-        $accessToken = json_decode(file_get_contents($credentialsPath), true);
-    } else {
-        // Request authorization from the user.
-        $authUrl = $client->createAuthUrl();
-        printf("Open the following link in your browser:\n%s\n", $authUrl);
-        print 'Enter verification code: ';
-        $authCode = trim(fgets(STDIN));
-
-        // Exchange authorization code for an access token.
-        $accessToken = $client->fetchAccessTokenWithAuthCode($authCode);
-
-        // Check to see if there was an error.
-        if (array_key_exists('error', $accessToken)) {
-            throw new Exception(join(', ', $accessToken));
-        }
-
-        // Store the credentials to disk.
-        if (!file_exists(dirname($credentialsPath))) {
-            mkdir(dirname($credentialsPath), 0700, true);
-        }
-        file_put_contents($credentialsPath, json_encode($accessToken));
-        printf("Credentials saved to %s\n", $credentialsPath);
+    // Load previously authorized token from a file, if it exists.
+    $tokenPath = 'token.json';
+    if (file_exists($tokenPath)) {
+        $accessToken = json_decode(file_get_contents($tokenPath), true);
+        $client->setAccessToken($accessToken);
     }
-    $client->setAccessToken($accessToken);
 
-    // Refresh the token if it's expired.
+    // If there is no previous token or it's expired.
     if ($client->isAccessTokenExpired()) {
-        $client->fetchAccessTokenWithRefreshToken($client->getRefreshToken());
-        file_put_contents($credentialsPath, json_encode($client->getAccessToken()));
+        // Refresh the token if possible, else fetch a new one.
+        if($client->getRefreshToken()) {
+            $client->fetchAccessTokenWithRefreshToken($client->getRefreshToken());
+        } else {
+            // Request authorization from the user.
+            $authUrl = $client->createAuthUrl();
+            printf("Open the following link in your browser:\n%s\n", $authUrl);
+            print 'Enter verification code: ';
+            $authCode = trim(fgets(STDIN));
+
+            // Exchange authorization code for an access token.
+            $accessToken = $client->fetchAccessTokenWithAuthCode($authCode);
+            $client->setAccessToken($accessToken);
+
+            // Check to see if there was an error.
+            if (array_key_exists('error', $accessToken)) {
+                throw new Exception(join(', ', $accessToken));
+            }
+        }
+        // Save the token to a file.
+        if (!file_exists(dirname($tokenPath))) {
+            mkdir(dirname($tokenPath), 0700, true);
+        }
+        file_put_contents($tokenPath, json_encode($client->getAccessToken()));
     }
     return $client;
 }

--- a/gmail/quickstart/quickstart.php
+++ b/gmail/quickstart/quickstart.php
@@ -44,7 +44,7 @@ function getClient()
     // If there is no previous token or it's expired.
     if ($client->isAccessTokenExpired()) {
         // Refresh the token if possible, else fetch a new one.
-        if($client->getRefreshToken()) {
+        if ($client->getRefreshToken()) {
             $client->fetchAccessTokenWithRefreshToken($client->getRefreshToken());
         } else {
             // Request authorization from the user.

--- a/people/quickstart/quickstart.php
+++ b/people/quickstart/quickstart.php
@@ -32,39 +32,41 @@ function getClient()
     $client->setScopes(Google_Service_PeopleService::CONTACTS_READONLY);
     $client->setAuthConfig('credentials.json');
     $client->setAccessType('offline');
+    $client->setPrompt('select_account consent');
 
-    // Load previously authorized credentials from a file.
-    $credentialsPath = 'token.json';
-    if (file_exists($credentialsPath)) {
-        $accessToken = json_decode(file_get_contents($credentialsPath), true);
-    } else {
-        // Request authorization from the user.
-        $authUrl = $client->createAuthUrl();
-        printf("Open the following link in your browser:\n%s\n", $authUrl);
-        print 'Enter verification code: ';
-        $authCode = trim(fgets(STDIN));
-
-        // Exchange authorization code for an access token.
-        $accessToken = $client->fetchAccessTokenWithAuthCode($authCode);
-
-        // Check to see if there was an error.
-        if (array_key_exists('error', $accessToken)) {
-            throw new Exception(join(', ', $accessToken));
-        }
-
-        // Store the credentials to disk.
-        if (!file_exists(dirname($credentialsPath))) {
-            mkdir(dirname($credentialsPath), 0700, true);
-        }
-        file_put_contents($credentialsPath, json_encode($accessToken));
-        printf("Credentials saved to %s\n", $credentialsPath);
+    // Load previously authorized token from a file, if it exists.
+    $tokenPath = 'token.json';
+    if (file_exists($tokenPath)) {
+        $accessToken = json_decode(file_get_contents($tokenPath), true);
+        $client->setAccessToken($accessToken);
     }
-    $client->setAccessToken($accessToken);
 
-    // Refresh the token if it's expired.
+    // If there is no previous token or it's expired.
     if ($client->isAccessTokenExpired()) {
-        $client->fetchAccessTokenWithRefreshToken($client->getRefreshToken());
-        file_put_contents($credentialsPath, json_encode($client->getAccessToken()));
+        // Refresh the token if possible, else fetch a new one.
+        if($client->getRefreshToken()) {
+            $client->fetchAccessTokenWithRefreshToken($client->getRefreshToken());
+        } else {
+            // Request authorization from the user.
+            $authUrl = $client->createAuthUrl();
+            printf("Open the following link in your browser:\n%s\n", $authUrl);
+            print 'Enter verification code: ';
+            $authCode = trim(fgets(STDIN));
+
+            // Exchange authorization code for an access token.
+            $accessToken = $client->fetchAccessTokenWithAuthCode($authCode);
+            $client->setAccessToken($accessToken);
+
+            // Check to see if there was an error.
+            if (array_key_exists('error', $accessToken)) {
+                throw new Exception(join(', ', $accessToken));
+            }
+        }
+        // Save the token to a file.
+        if (!file_exists(dirname($tokenPath))) {
+            mkdir(dirname($tokenPath), 0700, true);
+        }
+        file_put_contents($tokenPath, json_encode($client->getAccessToken()));
     }
     return $client;
 }

--- a/people/quickstart/quickstart.php
+++ b/people/quickstart/quickstart.php
@@ -44,7 +44,7 @@ function getClient()
     // If there is no previous token or it's expired.
     if ($client->isAccessTokenExpired()) {
         // Refresh the token if possible, else fetch a new one.
-        if($client->getRefreshToken()) {
+        if ($client->getRefreshToken()) {
             $client->fetchAccessTokenWithRefreshToken($client->getRefreshToken());
         } else {
             // Request authorization from the user.

--- a/sheets/quickstart/quickstart.php
+++ b/sheets/quickstart/quickstart.php
@@ -32,39 +32,41 @@ function getClient()
     $client->setScopes(Google_Service_Sheets::SPREADSHEETS_READONLY);
     $client->setAuthConfig('credentials.json');
     $client->setAccessType('offline');
+    $client->setPrompt('select_account consent');
 
-    // Load previously authorized credentials from a file.
-    $credentialsPath = 'token.json';
-    if (file_exists($credentialsPath)) {
-        $accessToken = json_decode(file_get_contents($credentialsPath), true);
-    } else {
-        // Request authorization from the user.
-        $authUrl = $client->createAuthUrl();
-        printf("Open the following link in your browser:\n%s\n", $authUrl);
-        print 'Enter verification code: ';
-        $authCode = trim(fgets(STDIN));
-
-        // Exchange authorization code for an access token.
-        $accessToken = $client->fetchAccessTokenWithAuthCode($authCode);
-
-        // Check to see if there was an error.
-        if (array_key_exists('error', $accessToken)) {
-            throw new Exception(join(', ', $accessToken));
-        }
-
-        // Store the credentials to disk.
-        if (!file_exists(dirname($credentialsPath))) {
-            mkdir(dirname($credentialsPath), 0700, true);
-        }
-        file_put_contents($credentialsPath, json_encode($accessToken));
-        printf("Credentials saved to %s\n", $credentialsPath);
+    // Load previously authorized token from a file, if it exists.
+    $tokenPath = 'token.json';
+    if (file_exists($tokenPath)) {
+        $accessToken = json_decode(file_get_contents($tokenPath), true);
+        $client->setAccessToken($accessToken);
     }
-    $client->setAccessToken($accessToken);
 
-    // Refresh the token if it's expired.
+    // If there is no previous token or it's expired.
     if ($client->isAccessTokenExpired()) {
-        $client->fetchAccessTokenWithRefreshToken($client->getRefreshToken());
-        file_put_contents($credentialsPath, json_encode($client->getAccessToken()));
+        // Refresh the token if possible, else fetch a new one.
+        if($client->getRefreshToken()) {
+            $client->fetchAccessTokenWithRefreshToken($client->getRefreshToken());
+        } else {
+            // Request authorization from the user.
+            $authUrl = $client->createAuthUrl();
+            printf("Open the following link in your browser:\n%s\n", $authUrl);
+            print 'Enter verification code: ';
+            $authCode = trim(fgets(STDIN));
+
+            // Exchange authorization code for an access token.
+            $accessToken = $client->fetchAccessTokenWithAuthCode($authCode);
+            $client->setAccessToken($accessToken);
+
+            // Check to see if there was an error.
+            if (array_key_exists('error', $accessToken)) {
+                throw new Exception(join(', ', $accessToken));
+            }
+        }
+        // Save the token to a file.
+        if (!file_exists(dirname($tokenPath))) {
+            mkdir(dirname($tokenPath), 0700, true);
+        }
+        file_put_contents($tokenPath, json_encode($client->getAccessToken()));
     }
     return $client;
 }

--- a/sheets/quickstart/quickstart.php
+++ b/sheets/quickstart/quickstart.php
@@ -44,7 +44,7 @@ function getClient()
     // If there is no previous token or it's expired.
     if ($client->isAccessTokenExpired()) {
         // Refresh the token if possible, else fetch a new one.
-        if($client->getRefreshToken()) {
+        if ($client->getRefreshToken()) {
             $client->fetchAccessTokenWithRefreshToken($client->getRefreshToken());
         } else {
             // Request authorization from the user.

--- a/slides/quickstart/quickstart.php
+++ b/slides/quickstart/quickstart.php
@@ -32,39 +32,41 @@ function getClient()
     $client->setScopes(Google_Service_Slides::PRESENTATIONS_READONLY);
     $client->setAuthConfig('credentials.json');
     $client->setAccessType('offline');
+    $client->setPrompt('select_account consent');
 
-    // Load previously authorized credentials from a file.
-    $credentialsPath = 'token.json';
-    if (file_exists($credentialsPath)) {
-        $accessToken = json_decode(file_get_contents($credentialsPath), true);
-    } else {
-        // Request authorization from the user.
-        $authUrl = $client->createAuthUrl();
-        printf("Open the following link in your browser:\n%s\n", $authUrl);
-        print 'Enter verification code: ';
-        $authCode = trim(fgets(STDIN));
-
-        // Exchange authorization code for an access token.
-        $accessToken = $client->fetchAccessTokenWithAuthCode($authCode);
-
-        // Check to see if there was an error.
-        if (array_key_exists('error', $accessToken)) {
-            throw new Exception(join(', ', $accessToken));
-        }
-
-        // Store the credentials to disk.
-        if (!file_exists(dirname($credentialsPath))) {
-            mkdir(dirname($credentialsPath), 0700, true);
-        }
-        file_put_contents($credentialsPath, json_encode($accessToken));
-        printf("Credentials saved to %s\n", $credentialsPath);
+    // Load previously authorized token from a file, if it exists.
+    $tokenPath = 'token.json';
+    if (file_exists($tokenPath)) {
+        $accessToken = json_decode(file_get_contents($tokenPath), true);
+        $client->setAccessToken($accessToken);
     }
-    $client->setAccessToken($accessToken);
 
-    // Refresh the token if it's expired.
+    // If there is no previous token or it's expired.
     if ($client->isAccessTokenExpired()) {
-        $client->fetchAccessTokenWithRefreshToken($client->getRefreshToken());
-        file_put_contents($credentialsPath, json_encode($client->getAccessToken()));
+        // Refresh the token if possible, else fetch a new one.
+        if($client->getRefreshToken()) {
+            $client->fetchAccessTokenWithRefreshToken($client->getRefreshToken());
+        } else {
+            // Request authorization from the user.
+            $authUrl = $client->createAuthUrl();
+            printf("Open the following link in your browser:\n%s\n", $authUrl);
+            print 'Enter verification code: ';
+            $authCode = trim(fgets(STDIN));
+
+            // Exchange authorization code for an access token.
+            $accessToken = $client->fetchAccessTokenWithAuthCode($authCode);
+            $client->setAccessToken($accessToken);
+
+            // Check to see if there was an error.
+            if (array_key_exists('error', $accessToken)) {
+                throw new Exception(join(', ', $accessToken));
+            }
+        }
+        // Save the token to a file.
+        if (!file_exists(dirname($tokenPath))) {
+            mkdir(dirname($tokenPath), 0700, true);
+        }
+        file_put_contents($tokenPath, json_encode($client->getAccessToken()));
     }
     return $client;
 }

--- a/slides/quickstart/quickstart.php
+++ b/slides/quickstart/quickstart.php
@@ -44,7 +44,7 @@ function getClient()
     // If there is no previous token or it's expired.
     if ($client->isAccessTokenExpired()) {
         // Refresh the token if possible, else fetch a new one.
-        if($client->getRefreshToken()) {
+        if ($client->getRefreshToken()) {
             $client->fetchAccessTokenWithRefreshToken($client->getRefreshToken());
         } else {
             // Request authorization from the user.

--- a/tasks/quickstart/quickstart.php
+++ b/tasks/quickstart/quickstart.php
@@ -32,39 +32,41 @@ function getClient()
     $client->setScopes(Google_Service_Tasks::TASKS_READONLY);
     $client->setAuthConfig('credentials.json');
     $client->setAccessType('offline');
+    $client->setPrompt('select_account consent');
 
-    // Load previously authorized credentials from a file.
-    $credentialsPath = 'token.json';
-    if (file_exists($credentialsPath)) {
-        $accessToken = json_decode(file_get_contents($credentialsPath), true);
-    } else {
-        // Request authorization from the user.
-        $authUrl = $client->createAuthUrl();
-        printf("Open the following link in your browser:\n%s\n", $authUrl);
-        print 'Enter verification code: ';
-        $authCode = trim(fgets(STDIN));
-
-        // Exchange authorization code for an access token.
-        $accessToken = $client->fetchAccessTokenWithAuthCode($authCode);
-
-        // Check to see if there was an error.
-        if (array_key_exists('error', $accessToken)) {
-            throw new Exception(join(', ', $accessToken));
-        }
-
-        // Store the credentials to disk.
-        if (!file_exists(dirname($credentialsPath))) {
-            mkdir(dirname($credentialsPath), 0700, true);
-        }
-        file_put_contents($credentialsPath, json_encode($accessToken));
-        printf("Credentials saved to %s\n", $credentialsPath);
+    // Load previously authorized token from a file, if it exists.
+    $tokenPath = 'token.json';
+    if (file_exists($tokenPath)) {
+        $accessToken = json_decode(file_get_contents($tokenPath), true);
+        $client->setAccessToken($accessToken);
     }
-    $client->setAccessToken($accessToken);
 
-    // Refresh the token if it's expired.
+    // If there is no previous token or it's expired.
     if ($client->isAccessTokenExpired()) {
-        $client->fetchAccessTokenWithRefreshToken($client->getRefreshToken());
-        file_put_contents($credentialsPath, json_encode($client->getAccessToken()));
+        // Refresh the token if possible, else fetch a new one.
+        if($client->getRefreshToken()) {
+            $client->fetchAccessTokenWithRefreshToken($client->getRefreshToken());
+        } else {
+            // Request authorization from the user.
+            $authUrl = $client->createAuthUrl();
+            printf("Open the following link in your browser:\n%s\n", $authUrl);
+            print 'Enter verification code: ';
+            $authCode = trim(fgets(STDIN));
+
+            // Exchange authorization code for an access token.
+            $accessToken = $client->fetchAccessTokenWithAuthCode($authCode);
+            $client->setAccessToken($accessToken);
+
+            // Check to see if there was an error.
+            if (array_key_exists('error', $accessToken)) {
+                throw new Exception(join(', ', $accessToken));
+            }
+        }
+        // Save the token to a file.
+        if (!file_exists(dirname($tokenPath))) {
+            mkdir(dirname($tokenPath), 0700, true);
+        }
+        file_put_contents($tokenPath, json_encode($client->getAccessToken()));
     }
     return $client;
 }

--- a/tasks/quickstart/quickstart.php
+++ b/tasks/quickstart/quickstart.php
@@ -44,7 +44,7 @@ function getClient()
     // If there is no previous token or it's expired.
     if ($client->isAccessTokenExpired()) {
         // Refresh the token if possible, else fetch a new one.
-        if($client->getRefreshToken()) {
+        if ($client->getRefreshToken()) {
             $client->fetchAccessTokenWithRefreshToken($client->getRefreshToken());
         } else {
             // Request authorization from the user.

--- a/vault/quickstart/quickstart.php
+++ b/vault/quickstart/quickstart.php
@@ -32,39 +32,41 @@ function getClient()
     $client->setScopes(Google_Service_Vault::EDISCOVERY_READONLY);
     $client->setAuthConfig('credentials.json');
     $client->setAccessType('offline');
+    $client->setPrompt('select_account consent');
 
-    // Load previously authorized credentials from a file.
-    $credentialsPath = 'token.json';
-    if (file_exists($credentialsPath)) {
-        $accessToken = json_decode(file_get_contents($credentialsPath), true);
-    } else {
-        // Request authorization from the user.
-        $authUrl = $client->createAuthUrl();
-        printf("Open the following link in your browser:\n%s\n", $authUrl);
-        print 'Enter verification code: ';
-        $authCode = trim(fgets(STDIN));
-
-        // Exchange authorization code for an access token.
-        $accessToken = $client->fetchAccessTokenWithAuthCode($authCode);
-
-        // Check to see if there was an error.
-        if (array_key_exists('error', $accessToken)) {
-            throw new Exception(join(', ', $accessToken));
-        }
-
-        // Store the credentials to disk.
-        if (!file_exists(dirname($credentialsPath))) {
-            mkdir(dirname($credentialsPath), 0700, true);
-        }
-        file_put_contents($credentialsPath, json_encode($accessToken));
-        printf("Credentials saved to %s\n", $credentialsPath);
+    // Load previously authorized token from a file, if it exists.
+    $tokenPath = 'token.json';
+    if (file_exists($tokenPath)) {
+        $accessToken = json_decode(file_get_contents($tokenPath), true);
+        $client->setAccessToken($accessToken);
     }
-    $client->setAccessToken($accessToken);
 
-    // Refresh the token if it's expired.
+    // If there is no previous token or it's expired.
     if ($client->isAccessTokenExpired()) {
-        $client->fetchAccessTokenWithRefreshToken($client->getRefreshToken());
-        file_put_contents($credentialsPath, json_encode($client->getAccessToken()));
+        // Refresh the token if possible, else fetch a new one.
+        if($client->getRefreshToken()) {
+            $client->fetchAccessTokenWithRefreshToken($client->getRefreshToken());
+        } else {
+            // Request authorization from the user.
+            $authUrl = $client->createAuthUrl();
+            printf("Open the following link in your browser:\n%s\n", $authUrl);
+            print 'Enter verification code: ';
+            $authCode = trim(fgets(STDIN));
+
+            // Exchange authorization code for an access token.
+            $accessToken = $client->fetchAccessTokenWithAuthCode($authCode);
+            $client->setAccessToken($accessToken);
+
+            // Check to see if there was an error.
+            if (array_key_exists('error', $accessToken)) {
+                throw new Exception(join(', ', $accessToken));
+            }
+        }
+        // Save the token to a file.
+        if (!file_exists(dirname($tokenPath))) {
+            mkdir(dirname($tokenPath), 0700, true);
+        }
+        file_put_contents($tokenPath, json_encode($client->getAccessToken()));
     }
     return $client;
 }

--- a/vault/quickstart/quickstart.php
+++ b/vault/quickstart/quickstart.php
@@ -44,7 +44,7 @@ function getClient()
     // If there is no previous token or it's expired.
     if ($client->isAccessTokenExpired()) {
         // Refresh the token if possible, else fetch a new one.
-        if($client->getRefreshToken()) {
+        if ($client->getRefreshToken()) {
             $client->fetchAccessTokenWithRefreshToken($client->getRefreshToken());
         } else {
             // Request authorization from the user.


### PR DESCRIPTION
Significant changes to the logic around handling access tokens. Ensures that `fetchAccessTokenWithRefreshToken()` is only called when a refresh token is present, and falls back to requesting a new token when one isn't. Sets the `prompt` OAuth2 parameter to ensure that the user sees the select account and consent screens, to ensure a refresh token is returned.

Prototyping on the Calendar quickstart, and will replicate out to the others once approved.

Fixes #16.