### PR TITLE
fix: slides_create_image URL

### DIFF
--- a/slides/snippets/src/SlidesSnippets.php
+++ b/slides/snippets/src/SlidesSnippets.php
@@ -134,27 +134,17 @@ class SlidesSnippets
     {
         $slidesService = $this->service;
         $driveService = $this->driveService;
+
+        $imageUrl = 'https://www.google.com/images/branding/'
+            . 'googlelogo/2x/googlelogo_color_272x92dp.png';
         // [START slides_create_image]
         // Temporarily upload a local image file to Drive, in order to obtain a URL
-        // for the image. Alternatively, you can provide the Slides servcie a URL of
+        // for the image. Alternatively, you can provide the Slides service a URL of
         // an already hosted image.
-        $file = new Google_Service_Drive_DriveFile(array(
-            'name' => 'My Image File',
-            'mimeType' => $imageMimeType
-        ));
-        $params = array(
-            'data' => file_get_contents($imageFilePath),
-            'uploadType' => 'media',
-        );
-        $upload = $driveService->files->create($file, $params);
-        $fileId = $upload->id;
-
-        // Obtain a URL for the image.
-        $token = $driveService->getClient()->fetchAccessTokenWithAssertion()['access_token'];
-        $endPoint = 'https://www.googleapis.com/drive/v3/files';
-        $imageUrl = sprintf('%s/%s?alt=media&access_token=%s', $endPoint, $fileId, $token);
-
-        // Create a new image, using the supplied object ID, with content downloaded from image_url.
+        //
+        // We will use an existing image under the variable: imageUrl.
+        //
+        // Create a new image, using the supplied object ID, with content downloaded from imageUrl.
         $imageId = 'MyImage_01';
         $emu4M = array('magnitude' => 4000000, 'unit' => 'EMU');
         $requests = array();

--- a/slides/snippets/src/SlidesSnippets.php
+++ b/slides/snippets/src/SlidesSnippets.php
@@ -130,19 +130,14 @@ class SlidesSnippets
         return $response;
     }
 
-    public function createImage($presentationId, $pageId, $imageFilePath, $imageMimeType)
+    public function createImage($presentationId, $pageId)
     {
         $slidesService = $this->service;
-        $driveService = $this->driveService;
 
         $imageUrl = 'https://www.google.com/images/branding/'
             . 'googlelogo/2x/googlelogo_color_272x92dp.png';
         // [START slides_create_image]
-        // Temporarily upload a local image file to Drive, in order to obtain a URL
-        // for the image. Alternatively, you can provide the Slides service a URL of
-        // an already hosted image.
-        //
-        // We will use an existing image under the variable: imageUrl.
+        // Provide the Slides service a URL in variable imageUrl of an already hosted image.
         //
         // Create a new image, using the supplied object ID, with content downloaded from imageUrl.
         $imageId = 'MyImage_01';
@@ -177,8 +172,6 @@ class SlidesSnippets
         $createImageResponse = $response->getReplies()[0]->getCreateImage();
         printf("Created image with ID: %s\n", $createImageResponse->getObjectId());
 
-        // Remove the temporary image file from Drive.
-        $driveService->files->delete($fileId);
         // [END slides_create_image]
         return $response;
     }

--- a/slides/snippets/tests/SlidesSnippetsTest.php
+++ b/slides/snippets/tests/SlidesSnippetsTest.php
@@ -21,7 +21,6 @@ class SlidesSnippetsTest extends BaseTestCase
 {
     const IMAGE_URL =
         'https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png';
-    const IMAGE_MIMETYPE = 'image/png';
     const TEMPLATE_PRESENTATION_ID = '1MmTR712m7U_kgeweE57POWwkEyWAV17AVAWjpmltmIg';
     const DATA_SPREADSHEET_ID = '14KaZMq2aCAGt5acV77zaA_Ps8aDt04G7T0ei4KiXLX8';
     const CHART_ID = 1107320627;
@@ -76,12 +75,7 @@ class SlidesSnippetsTest extends BaseTestCase
     {
         $presentationId = $this->createTestPresentation();
         $pageId = $this->createTestSlide($presentationId);
-        $response = $this->snippets->createImage(
-            $presentationId,
-            $pageId,
-            self::IMAGE_URL,
-            self::IMAGE_MIMETYPE
-        );
+        $response = $this->snippets->createImage($presentationId, $pageId);
         $this->assertEquals(1, sizeof($response->getReplies()), 'Unexpected number of replies.');
         $imageId = $response->getReplies()[0]->getCreateImage()->getObjectId();
         $this->assertNotNull($imageId, 'Missing image ID.');


### PR DESCRIPTION
Removes discouraged `getOAuthToken` method from  `slides_create_image` snippet.

Comment is copied from other samples:
https://devsite.googleplex.com/slides/how-tos/add-image